### PR TITLE
Enable extended binary with the v0.43 release.

### DIFF
--- a/0.43/Dockerfile
+++ b/0.43/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:2.4-alpine
 LABEL maintainer="ricardo@feliciano.tech"
 
 ENV HUGO_VERSION=0.43
-ENV HUGO_DOWNLOAD_URL=https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz
+ENV HUGO_DOWNLOAD_URL=https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz
 
 RUN apk add --update --no-cache --virtual build-dependencies
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -3,7 +3,7 @@ FROM ruby:2.4-alpine
 LABEL maintainer="ricardo@feliciano.tech"
 
 ENV HUGO_VERSION=%%HUGO_VERSION%%
-ENV HUGO_DOWNLOAD_URL=https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz
+ENV HUGO_DOWNLOAD_URL=https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz
 
 RUN apk add --update --no-cache --virtual build-dependencies
 


### PR DESCRIPTION
Fixes #62.